### PR TITLE
Simplify function names for better usability

### DIFF
--- a/.claude/commands/add-feature.md
+++ b/.claude/commands/add-feature.md
@@ -1,7 +1,7 @@
 READ specs/$ARGUMENT
 
 Before Starting:
-- GITHUB: create a issue with the title: Implement: maven-mcp-server
+- GITHUB: create a issue with the a short descriptive title.
 - GIT: checkout a branch and swith to it.
 
 IMPLEMENT TOOL

--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ To use this MCP server in your projects, add the following to your `.mcp.json` f
 
 ## Available Tools
 
-### Check Maven Version Exists
+### Check Version
 
 Verifies if a specific version of a Maven dependency exists in the Maven Central repository.
 
 ```
-check_maven_version_exists(
+check_version(
     dependency: str,
     version: str,
     packaging: str = "jar",
@@ -69,20 +69,20 @@ check_maven_version_exists(
 
 ```
 # Check if Spring Core 5.3.10 exists
-check_maven_version_exists: "org.springframework:spring-core" "5.3.10"
+check_version: "org.springframework:spring-core" "5.3.10"
 
 # Check with specific packaging
-check_maven_version_exists: "org.springframework:spring-web" "5.3.10" "jar"
+check_version: "org.springframework:spring-web" "5.3.10" "jar"
 
 # Check with classifier
-check_maven_version_exists: "org.springframework:spring-core" "5.3.10" "jar" "sources"
+check_version: "org.springframework:spring-core" "5.3.10" "jar" "sources"
 ```
 
 **Response Format:**
 - Success response:
   ```json
   {
-    "tool_name": "check_maven_version_exists",
+    "tool_name": "check_version",
     "status": "success",
     "result": {
       "exists": true
@@ -93,7 +93,7 @@ check_maven_version_exists: "org.springframework:spring-core" "5.3.10" "jar" "so
 - Error response:
   ```json
   {
-    "tool_name": "check_maven_version_exists",
+    "tool_name": "check_version",
     "status": "error",
     "error": {
       "code": "INVALID_INPUT_FORMAT",
@@ -102,12 +102,12 @@ check_maven_version_exists: "org.springframework:spring-core" "5.3.10" "jar" "so
   }
   ```
 
-### Get Maven Latest Version
+### Latest Version
 
 Retrieves the latest version of a Maven dependency from the Maven Central repository.
 
 ```
-get_maven_latest_version(
+latest_version(
     dependency: str,
     packaging: str = "jar",
     classifier: str | None = None
@@ -126,20 +126,20 @@ get_maven_latest_version(
 
 ```
 # Get latest version of Spring Core
-get_maven_latest_version: "org.springframework:spring-core"
+latest_version: "org.springframework:spring-core"
 
 # Get latest version with specific packaging
-get_maven_latest_version: "org.springframework:spring-web" "jar"
+latest_version: "org.springframework:spring-web" "jar"
 
 # Get latest version with classifier
-get_maven_latest_version: "org.springframework:spring-core" "jar" "sources"
+latest_version: "org.springframework:spring-core" "jar" "sources"
 ```
 
 **Response Format:**
 - Success response:
   ```json
   {
-    "tool_name": "get_maven_latest_version",
+    "tool_name": "latest_version",
     "status": "success",
     "result": {
       "latest_version": "6.0.13"
@@ -150,7 +150,7 @@ get_maven_latest_version: "org.springframework:spring-core" "jar" "sources"
 - Error response:
   ```json
   {
-    "tool_name": "get_maven_latest_version",
+    "tool_name": "latest_version",
     "status": "error",
     "error": {
       "code": "INVALID_INPUT_FORMAT",

--- a/specs/check-maven-version-exists-spec.md
+++ b/specs/check-maven-version-exists-spec.md
@@ -1,4 +1,4 @@
-# MCP Server Tool Spec - Check Maven Version Exists
+# MCP Server Tool Spec - Check Version
 
 > Verify if a specific version of a Maven dependency exists in the Maven Central repository.
 
@@ -10,7 +10,7 @@
 
 ### Tool Details
 - Implement in `src/maven_mcp_server/tools/version_exist.py`
-- **check_maven_version_exists()**
+- **check_version()**
   - Validate the dependency format (must be groupId:artifactId)
   - Validate the version string format
   - Query Maven Central API to check if the specific version exists
@@ -42,7 +42,7 @@
 ## Tool to Expose
 
 ```text
-check_maven_version_exists(
+check_version(
     dependency: str,
     version: str,
     packaging: str = "jar",
@@ -55,7 +55,7 @@ check_maven_version_exists(
   ```python
   # Success response
   {
-    "tool_name": "check_maven_version_exists",
+    "tool_name": "check_version",
     "status": "success",
     "result": {
         "exists": bool
@@ -64,7 +64,7 @@ check_maven_version_exists(
   
   # Error response
   {
-    "tool_name": "check_maven_version_exists",
+    "tool_name": "check_version",
     "status": "error",
     "error": {
         "code": str,  # One of the ErrorCode enum values

--- a/specs/get-maven-latest-version-spec.md
+++ b/specs/get-maven-latest-version-spec.md
@@ -1,4 +1,4 @@
-# MCP Server Tool Spec - Get Latest Version
+# MCP Server Tool Spec - Latest Version
 
 > Core functionality to retrieve the latest version of a Maven dependency from the Maven Central repository.
 
@@ -11,7 +11,7 @@
 
 ### Tool Details
 - Implement in `src/maven_mcp_server/tools/check_version.py`
-- **get_maven_latest_version()**
+- **latest_version()**
   - Validate the dependency format (must be groupId:artifactId)
   - Query Maven Central API to retrieve all versions
   - Apply semantic versioning comparison to determine the actual latest version
@@ -41,7 +41,7 @@
 ## Tool to Expose
 
 ```text
-get_maven_latest_version(
+latest_version(
     dependency: str, 
     packaging: str = "jar", 
     classifier: str | None = None
@@ -53,7 +53,7 @@ get_maven_latest_version(
   ```python
   # Success response
   {
-    "tool_name": "get_maven_latest_version",
+    "tool_name": "latest_version",
     "status": "success",
     "result": {
         "latest_version": str
@@ -62,7 +62,7 @@ get_maven_latest_version(
   
   # Error response
   {
-    "tool_name": "get_maven_latest_version",
+    "tool_name": "latest_version",
     "status": "error",
     "error": {
         "code": str,  # One of the ErrorCode enum values

--- a/src/maven_mcp_server/server.py
+++ b/src/maven_mcp_server/server.py
@@ -5,12 +5,12 @@ This module creates and configures the FastMCP server instance for the Maven MCP
 
 from mcp.server.fastmcp import FastMCP
 
-from maven_mcp_server.tools.version_exist import check_maven_version_exists
-from maven_mcp_server.tools.check_version import get_maven_latest_version
+from maven_mcp_server.tools.version_exist import check_version
+from maven_mcp_server.tools.check_version import latest_version
 
 # Create FastMCP server instance
 mcp = FastMCP("Maven MCP Server")
 
 # Register tools
-mcp.tool()(check_maven_version_exists)
-mcp.tool()(get_maven_latest_version)
+mcp.tool()(check_version)
+mcp.tool()(latest_version)

--- a/src/maven_mcp_server/tests/tools/test_check_version.py
+++ b/src/maven_mcp_server/tests/tools/test_check_version.py
@@ -1,6 +1,6 @@
 """Tests for the Maven latest version retrieval tool.
 
-This module tests the get_maven_latest_version tool and related functions.
+This module tests the latest_version tool and related functions.
 """
 
 import pytest
@@ -10,7 +10,7 @@ from unittest.mock import patch, MagicMock
 from mcp.server.fastmcp.exceptions import ValidationError, ResourceError, ToolError
 
 from maven_mcp_server.tools.check_version import (
-    get_maven_latest_version,
+    latest_version,
     _fetch_all_versions_from_maven_central
 )
 from maven_mcp_server.shared.utils import (
@@ -20,15 +20,15 @@ from maven_mcp_server.shared.utils import (
 )
 
 
-class TestGetMavenLatestVersion:
-    """Tests for the get_maven_latest_version function."""
+class TestLatestVersion:
+    """Tests for the latest_version function."""
     
     @patch("maven_mcp_server.tools.check_version._fetch_all_versions_from_maven_central")
     def test_successful_retrieval(self, mock_fetch):
         """Test a successful latest version retrieval."""
         mock_fetch.return_value = ["5.3.9", "5.3.10", "5.3.11"]
         
-        result = get_maven_latest_version(
+        result = latest_version(
             "org.springframework:spring-core"
         )
         
@@ -43,7 +43,7 @@ class TestGetMavenLatestVersion:
         """Test with a mix of regular and snapshot versions."""
         mock_fetch.return_value = ["5.3.9", "5.3.10", "5.3.11", "5.3.12-SNAPSHOT"]
         
-        result = get_maven_latest_version(
+        result = latest_version(
             "org.springframework:spring-core"
         )
         
@@ -53,7 +53,7 @@ class TestGetMavenLatestVersion:
     def test_invalid_dependency_format(self):
         """Test with an invalid dependency format."""
         with pytest.raises(ValidationError):
-            get_maven_latest_version(
+            latest_version(
                 "org.springframework.spring-core"  # Invalid format
             )
     
@@ -62,7 +62,7 @@ class TestGetMavenLatestVersion:
         """Test with a custom packaging type."""
         mock_fetch.return_value = ["5.3.9", "5.3.10", "5.3.11"]
         
-        result = get_maven_latest_version(
+        result = latest_version(
             "org.springframework:spring-core",
             "war"
         )
@@ -78,7 +78,7 @@ class TestGetMavenLatestVersion:
         # Mock that the latest version has the classifier
         mock_check_artifact.return_value = True
         
-        result = get_maven_latest_version(
+        result = latest_version(
             "org.springframework:spring-core",
             "jar",
             "sources"
@@ -102,7 +102,7 @@ class TestGetMavenLatestVersion:
         # Mock that the latest version doesn't have the classifier but an older one does
         mock_check_artifact.side_effect = lambda g, a, v, p, c: v == "5.3.10"
         
-        result = get_maven_latest_version(
+        result = latest_version(
             "org.springframework:spring-core",
             "jar",
             "sources"
@@ -116,7 +116,7 @@ class TestGetMavenLatestVersion:
         """Test with a BOM dependency."""
         mock_fetch.return_value = ["5.3.9", "5.3.10", "5.3.11"]
         
-        result = get_maven_latest_version(
+        result = latest_version(
             "org.springframework:spring-bom"
         )
         
@@ -131,7 +131,7 @@ class TestGetMavenLatestVersion:
         
         # The exception can be either a ResourceError directly or wrapped in a ToolError
         try:
-            get_maven_latest_version(
+            latest_version(
                 "org.springframework:spring-core"
             )
             pytest.fail("Expected exception was not raised")
@@ -145,7 +145,7 @@ class TestGetMavenLatestVersion:
         mock_fetch.side_effect = requests.RequestException("Connection error")
         
         with pytest.raises(ResourceError):
-            get_maven_latest_version(
+            latest_version(
                 "org.springframework:spring-core"
             )
     
@@ -155,7 +155,7 @@ class TestGetMavenLatestVersion:
         mock_fetch.side_effect = Exception("Unexpected error")
         
         with pytest.raises(ToolError):
-            get_maven_latest_version(
+            latest_version(
                 "org.springframework:spring-core"
             )
 

--- a/src/maven_mcp_server/tests/tools/test_version_exist.py
+++ b/src/maven_mcp_server/tests/tools/test_version_exist.py
@@ -1,6 +1,6 @@
 """Tests for the Maven version existence checking tool.
 
-This module tests the check_maven_version_exists tool and related functions.
+This module tests the check_version tool and related functions.
 """
 
 import pytest
@@ -10,21 +10,21 @@ from unittest.mock import patch, MagicMock
 from mcp.server.fastmcp.exceptions import ValidationError, ResourceError, ToolError
 
 from maven_mcp_server.tools.version_exist import (
-    check_maven_version_exists,
+    check_version,
     _check_version_exists_in_maven_central,
     _check_version_in_metadata
 )
 
 
-class TestCheckMavenVersionExists:
-    """Tests for the check_maven_version_exists function."""
+class TestCheckVersion:
+    """Tests for the check_version function."""
     
     @patch("maven_mcp_server.tools.version_exist._check_version_exists_in_maven_central")
     def test_successful_check_true(self, mock_check):
         """Test a successful version check that returns True."""
         mock_check.return_value = True
         
-        result = check_maven_version_exists(
+        result = check_version(
             "org.springframework:spring-core",
             "5.3.10"
         )
@@ -43,7 +43,7 @@ class TestCheckMavenVersionExists:
         """Test a successful version check that returns False."""
         mock_check.return_value = False
         
-        result = check_maven_version_exists(
+        result = check_version(
             "org.springframework:spring-core",
             "999.999.999"  # Non-existent version
         )
@@ -53,7 +53,7 @@ class TestCheckMavenVersionExists:
     def test_invalid_dependency_format(self):
         """Test with an invalid dependency format."""
         with pytest.raises(ValidationError):
-            check_maven_version_exists(
+            check_version(
                 "org.springframework.spring-core",  # Invalid format
                 "5.3.10"
             )
@@ -61,7 +61,7 @@ class TestCheckMavenVersionExists:
     def test_invalid_version_format(self):
         """Test with an invalid version format."""
         with pytest.raises(ValidationError):
-            check_maven_version_exists(
+            check_version(
                 "org.springframework:spring-core",
                 "invalid-version"  # Invalid format
             )
@@ -71,7 +71,7 @@ class TestCheckMavenVersionExists:
         """Test with a custom packaging type."""
         mock_check.return_value = True
         
-        result = check_maven_version_exists(
+        result = check_version(
             "org.springframework:spring-core",
             "5.3.10",
             "war"
@@ -91,7 +91,7 @@ class TestCheckMavenVersionExists:
         """Test with a classifier."""
         mock_check.return_value = True
         
-        result = check_maven_version_exists(
+        result = check_version(
             "org.springframework:spring-core",
             "5.3.10",
             "jar",
@@ -112,7 +112,7 @@ class TestCheckMavenVersionExists:
         """Test with a BOM dependency."""
         mock_check.return_value = True
         
-        result = check_maven_version_exists(
+        result = check_version(
             "org.springframework:spring-bom",
             "5.3.10"
         )
@@ -133,7 +133,7 @@ class TestCheckMavenVersionExists:
         mock_check.side_effect = requests.RequestException("Connection error")
         
         with pytest.raises(ResourceError):
-            check_maven_version_exists(
+            check_version(
                 "org.springframework:spring-core",
                 "5.3.10"
             )
@@ -144,7 +144,7 @@ class TestCheckMavenVersionExists:
         mock_check.side_effect = Exception("Unexpected error")
         
         with pytest.raises(ToolError):
-            check_maven_version_exists(
+            check_version(
                 "org.springframework:spring-core",
                 "5.3.10"
             )

--- a/src/maven_mcp_server/tools/check_version.py
+++ b/src/maven_mcp_server/tools/check_version.py
@@ -21,7 +21,7 @@ from maven_mcp_server.shared.utils import (
 )
 
 
-def get_maven_latest_version(
+def latest_version(
     dependency: str,
     packaging: str = "jar",
     classifier: Optional[str] = None

--- a/src/maven_mcp_server/tools/version_exist.py
+++ b/src/maven_mcp_server/tools/version_exist.py
@@ -18,7 +18,7 @@ from maven_mcp_server.shared.utils import (
 )
 
 
-def check_maven_version_exists(
+def check_version(
     dependency: str,
     version: str,
     packaging: str = "jar",


### PR DESCRIPTION
## Summary
Simplify the MCP tool function names to make the API more user-friendly and intuitive.

## Changes
- Rename `check_maven_version_exists` to `check_version`
- Rename `get_maven_latest_version` to `latest_version` 
- Update all related function calls, imports, and tests
- Update documentation in README.md
- Update specifications in specs folder

## Technical Details
- All tests pass after the refactoring
- No changes to actual functionality, only to the function names
- This is a breaking change for any existing client code using the old names

Fixes #5

🤖 Generated with [Claude Code](https://claude.ai/code)