### PR TITLE
Potential fix for code scanning alert no. 2: Unnecessary pass

### DIFF
--- a/src/mvn_mcp_server/tests/services/test_maven_api.py
+++ b/src/mvn_mcp_server/tests/services/test_maven_api.py
@@ -160,7 +160,6 @@ class TestMavenApiService(unittest.TestCase):
             self.api_service.get_all_versions("org.example", "test-artifact")
 
         # Just verify that a ResourceError was raised - specific message is implementation detail
-        pass
 
     @patch("requests.get")
     def test_search_artifacts(self, mock_get):


### PR DESCRIPTION
Potential fix for [https://github.com/danielscholl/mvn-mcp-server/security/code-scanning/2](https://github.com/danielscholl/mvn-mcp-server/security/code-scanning/2)

To fix this problem, remove the unnecessary `pass` statement from line 163 in the `test_get_all_versions_empty` method within `src/mvn_mcp_server/tests/services/test_maven_api.py`. No additional imports, method, or variable definitions are needed for this change. The other code in this method makes it a non-empty block, so the removal of `pass` does not affect functionality or clarity.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
