### PR TITLE
Potential fix for code scanning alert no. 1: Empty except

### DIFF
--- a/src/mvn_mcp_server/services/version.py
+++ b/src/mvn_mcp_server/services/version.py
@@ -92,7 +92,10 @@ class VersionService:
                 )
                 return [year, month, day]
         except (ValueError, IndexError):
-            logger.debug(f"Failed to parse calendar version from '{base_version}'.", exc_info=True)
+            logger.debug(
+                f"Failed to parse calendar version from '{base_version}'.",
+                exc_info=True,
+            )
 
         return None
 

--- a/src/mvn_mcp_server/services/version.py
+++ b/src/mvn_mcp_server/services/version.py
@@ -92,7 +92,7 @@ class VersionService:
                 )
                 return [year, month, day]
         except (ValueError, IndexError):
-            pass
+            logger.debug(f"Failed to parse calendar version from '{base_version}'.", exc_info=True)
 
         return None
 


### PR DESCRIPTION
Potential fix for [https://github.com/danielscholl/mvn-mcp-server/security/code-scanning/1](https://github.com/danielscholl/mvn-mcp-server/security/code-scanning/1)

The fix is to provide some form of handling within the `except (ValueError, IndexError):` block. The best solution, given the presence of a logger in the class, is to add a debug-level log message in the except block. This documents that a parsing exception occurred, and, because parsing failure is an expected possibility, using DEBUG instead of ERROR avoids log spamming but retains context for debugging. No new imports are needed; just add one call to `logger.debug()` with an explanatory message in the except block inside the `_try_calendar_version` function of `VersionService` in `src/mvn_mcp_server/services/version.py`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
