### PR TITLE
docs: remove redundant server workflow description from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,13 +129,6 @@ graph LR
     B -->|Structured Response| A
 ```
 
-The server:
-1. Translates natural language to Maven API calls
-2. Queries Maven Central for version/dependency data
-3. Optionally scans with Trivy for vulnerabilities
-4. Returns comprehensive, AI-optimized responses
-5. Caches results for efficiency
-
 ## Support
 
 - **Issues**: [GitHub Issues](https://github.com/danielscholl/mvn-mcp-server/issues)


### PR DESCRIPTION
## Summary

This change removes documentation content from the README.md file, specifically eliminating a numbered list that described the server's operational workflow.

## Key Modifications

### Documentation Removal
- **Deleted content**: Removed a 5-point list explaining the server's core functionality
  - Natural language to Maven API call translation
  - Maven Central querying for version/dependency data
  - Optional Trivy vulnerability scanning
  - AI-optimized response formatting
  - Result caching mechanism

### Structural Impact
- The Mermaid diagram showing the interaction flow between MCP Client and Maven Central Server remains intact
- The removal creates a gap between the architecture diagram and the Support section, eliminating the textual explanation of the server's operational steps