### PR TITLE
ci(release): fix uv build system flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Build package
         run: |
-          uv pip install build
+          uv pip install --system build
           uv run python -m build
 
       - name: Validate built distributions
@@ -96,7 +96,7 @@ jobs:
 
       - name: Build package
         run: |
-          uv pip install build
+          uv pip install --system build
           uv run python -m build
 
       - name: Validate built distributions


### PR DESCRIPTION
## Summary of Changes

Modified the GitHub Actions release workflow to add the `--system` flag to `uv pip install` commands when installing the `build` package.

## Key Modifications

### Workflow Configuration Updates

- **Build Step Modification (Line 57)**: Changed `uv pip install build` to `uv pip install --system build` in the first build job
- **Build Step Modification (Line 99)**: Applied the same change to `uv pip install build` → `uv pip install --system build` in the second build job

## Technical Details

The `--system` flag instructs `uv` to install packages into the system Python environment rather than creating or using a virtual environment. This change affects two separate build jobs in the release workflow, ensuring consistent package installation behavior across both jobs where the `build` package is required for creating Python distributions