### PR TITLE
ci(release): fix build command by removing uv run prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Build package
         run: |
           uv pip install --system build
-          uv run python -m build
+          python -m build
 
       - name: Validate built distributions
         run: |
@@ -97,7 +97,7 @@ jobs:
       - name: Build package
         run: |
           uv pip install --system build
-          uv run python -m build
+          python -m build
 
       - name: Validate built distributions
         run: |


### PR DESCRIPTION
## Problem

Manual publish workflow failing with:
```
/home/runner/work/mvn-mcp-server/mvn-mcp-server/.venv/bin/python: No module named build
```

## Root Cause

The build command was using:
```bash
uv pip install --system build
uv run python -m build
```

- `uv pip install --system` installs `build` into system Python
- `uv run` creates a NEW venv and runs python inside it
- The new venv doesn't have `build` installed → error

## Solution

Remove `uv run` prefix and use system Python directly:
```bash
uv pip install --system build
python -m build
```

This uses the system Python where `build` is installed.

## Testing

Manual publish workflow should now succeed when triggered.