### PR TITLE
feat(deps): update core dependencies and align documentation

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -73,8 +73,8 @@
   color: c5def5
   description: Architecture Decision Record needed or updated
 
-# Service Labels (Which OSDU service)
-  
+# Component Labels (Specific areas)
+
 
 # Status Labels (Current state)
 - name: help wanted

--- a/README.md
+++ b/README.md
@@ -117,18 +117,6 @@ Without Trivy, version checking and dependency analysis work normally. Security 
 | **triage** | Complete dependency and vulnerability analysis | `Run triage for my-service` |
 | **plan** | Generate actionable remediation plan | `Create update plan for my-service` |
 
-## How It Works
-
-```mermaid
-graph LR
-    A[AI Assistant] -->|Natural Language| B[MCP Server]
-    B -->|API Calls| C[Maven Central]
-    B -->|Security Scan| D[Trivy]
-    C -->|Version Data| B
-    D -->|CVE Data| B
-    B -->|Structured Response| A
-```
-
 ## License
 
 This project is licensed under the MIT License - see [LICENSE](LICENSE) for details.
@@ -137,6 +125,6 @@ This project is licensed under the MIT License - see [LICENSE](LICENSE) for deta
 
 <div align="center">
 
-**[Usage](docs/project-usage.md)** • **[Architecture](docs/project-architect.md)** • **[Contributing](CONTRIBUTING.md)**
+**[Usage](https://github.com/danielscholl/mvn-mcp-server/blob/main/docs/project-usage.md)** • **[Architecture](https://github.com/danielscholl/mvn-mcp-server/blob/main/docs/project-architect.md)** • **[Contributing](https://github.com/danielscholl/mvn-mcp-server/blob/main/CONTRIBUTING.md)**
 
 </div>

--- a/docs/adr/001-mcp-framework-selection.md
+++ b/docs/adr/001-mcp-framework-selection.md
@@ -4,7 +4,7 @@
 **Accepted** - 2025-05-15
 
 ## Context
-We need to implement an MCP (Model Context Protocol) server to expose OSDU functionality to AI assistants. The implementation must be reliable, maintainable, and allow for rapid development while ensuring protocol compliance.
+We need to implement an MCP (Model Context Protocol) server to provide Maven dependency management capabilities to AI assistants. The implementation must be reliable, maintainable, and allow for rapid development while ensuring protocol compliance.
 
 ## Decision
 Use **FastMCP** framework for implementing the MCP server.
@@ -44,7 +44,7 @@ Use **FastMCP** framework for implementing the MCP server.
 # Simple tool registration pattern
 from fastmcp import FastMCP
 
-mcp = FastMCP("Maven MCP Server")
+mcp = FastMCP("mvn MCP Server")
 
 @mcp.tool()
 def check_version(dependency: str, version: str) -> dict:

--- a/docs/adr/002-synchronous-architecture-choice.md
+++ b/docs/adr/002-synchronous-architecture-choice.md
@@ -9,14 +9,14 @@ When implementing the Maven MCP Server, we needed to decide between an asynchron
 The FastMCP framework supports both patterns, and Maven Central API calls are I/O-bound operations that could benefit from async handling.
 
 ## Decision
-Use **synchronous (non-async)** implementation throughout the entire codebase.
+Use **synchronous (non-async)** implementation for tools and services. Prompts and resources use async as required by FastMCP framework.
 
 ## Rationale
 1. **Maven Operations are Sequential**: Most Maven operations follow a sequential pattern (check existence → fetch metadata → parse versions)
-2. **Simplicity**: Synchronous code is easier to understand, debug, and maintain
-3. **No Concurrency Requirements**: MCP servers typically handle one request at a time from the AI assistant
-4. **Framework Alignment**: FastMCP's examples and patterns favor synchronous implementation
-5. **Error Handling**: Synchronous error handling is more straightforward with try/catch blocks
+2. **Simplicity**: Synchronous code is easier to understand, debug, and maintain for core tool logic
+3. **No Concurrency Requirements**: Individual tool calls don't benefit from async patterns
+4. **Hybrid Architecture**: FastMCP requires async for prompts/resources but allows sync for tools
+5. **Error Handling**: Synchronous error handling is more straightforward with try/catch blocks for business logic
 
 ## Alternatives Considered
 1. **Full Async Implementation**
@@ -38,10 +38,12 @@ Use **synchronous (non-async)** implementation throughout the entire codebase.
 - Standard exception handling patterns
 
 **Negative:**
-- Limited concurrent request handling
+- Limited concurrent request handling in tools
 - Potential blocking on slow Maven Central responses
-- Cannot leverage async benefits if scale requirements change
+- Hybrid codebase with both sync (tools) and async (prompts/resources) patterns
 - Sequential processing of batch operations
+
+**Note:** Prompts and Resources use async as required by FastMCP framework for proper state management and MCP protocol compliance.
 
 ## Implementation Example
 ```python

--- a/docs/adr/010-dependency-management-strategy.md
+++ b/docs/adr/010-dependency-management-strategy.md
@@ -7,9 +7,9 @@
 During initial setup and testing, we discovered that the project's dependencies needed refinement. The original imports referenced `mcp.server.fastmcp` which doesn't exist in the current FastMCP package structure. Additionally, we needed to clarify our HTTP client strategy.
 
 ## Decision
-1. Use **FastMCP** (>=2.0.0) as the primary MCP framework dependency
-2. Use **httpx** (>=0.27.0) as the primary HTTP client for Maven Central API calls
-3. Maintain **requests** (>=2.32.3) for compatibility with existing code
+1. Use **FastMCP** (>=2.12.4) as the primary MCP framework dependency
+2. Use **httpx** (>=0.28.1) as the primary HTTP client for Maven Central API calls
+3. Maintain **requests** (>=2.32.5) for compatibility with existing code
 4. Use direct imports from `fastmcp` package (not nested paths)
 
 ## Rationale
@@ -17,7 +17,7 @@ During initial setup and testing, we discovered that the project's dependencies 
 ### FastMCP vs MCP
 - FastMCP is the actively maintained framework that provides the features we need
 - The `mcp` package alone doesn't provide the server framework capabilities
-- FastMCP 2.0+ has stable APIs and better exception handling
+- FastMCP 2.12+ provides stable APIs, prompts, resources, and improved exception handling
 
 ### Import Pattern
 - The correct import is `from fastmcp import FastMCP`, not `from mcp.server.fastmcp`
@@ -58,17 +58,17 @@ import requests  # For compatibility
 ### pyproject.toml Dependencies
 ```toml
 dependencies = [
-    "fastmcp>=2.0.0",
-    "pydantic>=2.11.4",
-    "requests>=2.32.3",
-    "httpx>=0.27.0",
+    "fastmcp>=2.12.4",
+    "pydantic>=2.11.10",
+    "requests>=2.32.5",
+    "httpx>=0.28.1",
 ]
 ```
 
 ## Migration Guide
 When updating existing code:
 1. Replace `from mcp.server.fastmcp` with `from fastmcp`
-2. Ensure FastMCP version is >=2.0.0
+2. Ensure FastMCP version is >=2.12.4 for prompts and resources support
 3. Add httpx to dependencies if using MavenApiService
 
 ## References

--- a/docs/project-architect.md
+++ b/docs/project-architect.md
@@ -50,10 +50,10 @@ This document covers:
 
 ### 2.3. Technology Stack
 - **Runtime**: Python 3.12+
-- **MCP Framework**: FastMCP (>=2.0.0)
+- **MCP Framework**: FastMCP (>=2.12.4)
 - **Validation**: Pydantic v2
-- **HTTP Client**: httpx (>=0.27.0) - direct dependency for Maven Central API
-- **HTTP Library**: requests (>=2.32.3) - for compatibility
+- **HTTP Client**: httpx (>=0.28.1) - direct dependency for Maven Central API
+- **HTTP Library**: requests (>=2.32.5) - for compatibility
 - **Testing**: pytest with unittest.mock
 - **Package Management**: UV
 
@@ -125,7 +125,28 @@ This document covers:
 └─────────────────────────────────────────┘
 ```
 
-### 3.2. Component Structure
+### 3.2. External Integration Flow
+
+The following diagram illustrates how data flows between the AI assistant, MCP server, and external services:
+
+```mermaid
+graph LR
+    A[AI Assistant] -->|Natural Language| B[MCP Server]
+    B -->|API Calls| C[Maven Central]
+    B -->|Security Scan| D[Trivy]
+    C -->|Version Data| B
+    D -->|CVE Data| B
+    B -->|Structured Response| A
+```
+
+**Key Integration Points:**
+- **Maven Central API**: Version metadata, dependency search, artifact availability
+- **Trivy Scanner**: Security vulnerability detection and CVE analysis
+- **AI Assistant**: Natural language queries and structured responses
+
+All processing happens locally - only Maven Central API queries are sent to external services.
+
+### 3.3. Component Structure
 
 ```
 mvn_mcp_server/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ maintainers = [
 readme = "README.md"
 requires-python = ">=3.12"
 license = {text = "MIT"}
-keywords = ["mcp", "maven", "osdu", "model-context-protocol", "dependency-management"]
+keywords = ["mcp", "maven", "model-context-protocol", "dependency-management"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Programming Language :: Python :: 3",
@@ -20,10 +20,10 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "fastmcp>=2.8.0",
-    "pydantic>=2.11.4",
-    "requests>=2.32.3",
-    "httpx>=0.27.0",
+    "fastmcp>=2.12.4",
+    "pydantic>=2.11.10",
+    "requests>=2.32.5",
+    "httpx>=0.28.1",
 ]
 
 [project.urls]

--- a/src/mvn_mcp_server/services/__init__.py
+++ b/src/mvn_mcp_server/services/__init__.py
@@ -1,6 +1,6 @@
 """Services module for mvn MCP Server.
 
 This module contains core services used by all tools, providing a common
-abstraction layer for mvn OSDU Assistant interactions, version parsing,
+abstraction layer for Maven Central interactions, version parsing,
 and caching.
 """

--- a/uv.lock
+++ b/uv.lock
@@ -673,7 +673,7 @@ wheels = [
 
 [[package]]
 name = "mvn-mcp-server"
-version = "0.2.0"
+version = "2.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
@@ -695,15 +695,15 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "black", marker = "extra == 'dev'" },
-    { name = "fastmcp", specifier = ">=2.8.0" },
+    { name = "fastmcp", specifier = ">=2.12.4" },
     { name = "flake8", marker = "extra == 'dev'" },
-    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "mypy", marker = "extra == 'dev'" },
-    { name = "pydantic", specifier = ">=2.11.4" },
+    { name = "pydantic", specifier = ">=2.11.10" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
-    { name = "requests", specifier = ">=2.32.3" },
+    { name = "requests", specifier = ">=2.32.5" },
 ]
 provides-extras = ["dev"]
 
@@ -876,7 +876,7 @@ wheels = [
 
 [[package]]
 name = "pydantic"
-version = "2.11.9"
+version = "2.11.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
@@ -884,9 +884,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ff/5d/09a551ba512d7ca404d785072700d3f6727a02f6f3c24ecfd081c7cf0aa8/pydantic-2.11.9.tar.gz", hash = "sha256:6b8ffda597a14812a7975c90b82a8a2e777d9257aba3453f973acd3c032a18e2", size = 788495, upload-time = "2025-09-13T11:26:39.325Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/54/ecab642b3bed45f7d5f59b38443dcb36ef50f85af192e6ece103dbfe9587/pydantic-2.11.10.tar.gz", hash = "sha256:dc280f0982fbda6c38fada4e476dc0a4f3aeaf9c6ad4c28df68a666ec3c61423", size = 788494, upload-time = "2025-10-04T10:40:41.338Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3e/d3/108f2006987c58e76691d5ae5d200dd3e0f532cb4e5fa3560751c3a1feba/pydantic-2.11.9-py3-none-any.whl", hash = "sha256:c42dd626f5cfc1c6950ce6205ea58c93efa406da65f479dcb4029d5934857da2", size = 444855, upload-time = "2025-09-13T11:26:36.909Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/1f/73c53fcbfb0b5a78f91176df41945ca466e71e9d9d836e5c522abda39ee7/pydantic-2.11.10-py3-none-any.whl", hash = "sha256:802a655709d49bd004c31e865ef37da30b540786a46bfce02333e0e24b5fe29a", size = 444823, upload-time = "2025-10-04T10:40:39.055Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary
This merge request updates project documentation, dependency versions, and removes OSDU-specific references to better reflect the project's focus as a Maven dependency management MCP server.

## Key Modifications

### Documentation Updates
- **README.md**: Removed the "How It Works" mermaid diagram from the main README and converted relative documentation links to absolute GitHub URLs for better accessibility
- **Architecture Documentation**: Moved the external integration flow diagram from README to `docs/project-architect.md` under a new section (3.2) with expanded context about Maven Central API, Trivy Scanner, and AI Assistant integration points
- **ADR Updates**: 
  - ADR-001: Changed context from "OSDU functionality" to "Maven dependency management capabilities"
  - ADR-002: Updated decision statement to clarify hybrid architecture (synchronous tools/services, async prompts/resources as required by FastMCP)
  - ADR-010: Updated all dependency version requirements to match current specifications

### Dependency Version Updates
Updated minimum required versions in `pyproject.toml` and documentation:
- `fastmcp`: 2.8.0 → 2.12.4 (adds prompts and resources support)
- `pydantic`: 2.11.4 → 2.11.10
- `requests`: 2.32.3 → 2.32.5
- `httpx`: 0.27.0 → 0.28.1

### Project Metadata Changes
- **Keywords**: Removed "osdu" keyword from `pyproject.toml` to better reflect project scope
- **Version**: Updated from 0.2.0 to 2.0.0 in `uv.lock`
- **Labels Configuration**: Changed comment from "Service Labels (Which OSDU service)" to "Component Labels (Specific areas)" in `.github/labels.yml`
- **Code Comments**: Updated `services/__init__.py` docstring from "mvn OSDU Assistant interactions" to "Maven Central interactions"

### Lock File Updates
The `uv.lock` file reflects the dependency version changes with updated package hashes and metadata for `pydantic` (2.11.9 → 2.11.10) and all `mvn-mcp-server` dependencies