### PR TITLE
style(maven): format multi-line log message for readability

### DIFF
--- a/src/mvn_mcp_server/services/maven_effective_pom.py
+++ b/src/mvn_mcp_server/services/maven_effective_pom.py
@@ -41,7 +41,9 @@ class MavenEffectivePomService:
                     maven_version = result.stdout.split()[2]
                     logger.info(f"Maven available: {maven_version}")
                 except (IndexError, AttributeError):
-                    logger.info("Maven available, but version could not be determined from output.")
+                    logger.info(
+                        "Maven available, but version could not be determined from output."
+                    )
                 return True
             else:
                 logger.warning(f"Maven check failed: {result.stderr}")


### PR DESCRIPTION
## Summary
Version bump from 2.0.0 to 2.2.0 for the mvn-mcp-server package in the lock file.

## Key Modifications
- **Package Version Update**: Updated `mvn-mcp-server` from version `2.0.0` to `2.2.0` in `uv.lock`
- The package remains configured as an editable source installation
- Dependency structure (fastmcp) remains unchanged

## Technical Details
- This is a minor version increment (2.0.0 → 2.2.0) following semantic versioning
- The lock file update suggests dependency resolution was re-run, potentially incorporating bug fixes or new features from the 2.1.x and 2.2.0 releases
- The editable source configuration indicates this is a local development package being tracked in the lock file