### PR TITLE
fix(mcp): use Annotated types for list parameters in scan tool

### DIFF
--- a/src/mvn_mcp_server/server.py
+++ b/src/mvn_mcp_server/server.py
@@ -235,11 +235,20 @@ def list_available_versions_tool(
 )
 def scan_java_project_tool(
     workspace: str,
-    include_profiles: Annotated[Optional[List[str]], Field(default=None, description="List of Maven profiles to activate")] = None,
+    include_profiles: Annotated[
+        Optional[List[str]],
+        Field(default=None, description="List of Maven profiles to activate"),
+    ] = None,
     scan_all_modules: bool = True,
     scan_mode: str = "workspace",
     pom_file: Optional[str] = None,
-    severity_filter: Annotated[Optional[List[str]], Field(default=None, description="List of severity levels to include (CRITICAL, HIGH, MEDIUM, LOW)")] = None,
+    severity_filter: Annotated[
+        Optional[List[str]],
+        Field(
+            default=None,
+            description="List of severity levels to include (CRITICAL, HIGH, MEDIUM, LOW)",
+        ),
+    ] = None,
     max_results: int = 100,
     offset: int = 0,
 ):

--- a/src/mvn_mcp_server/server.py
+++ b/src/mvn_mcp_server/server.py
@@ -4,7 +4,8 @@ This module creates and configures the FastMCP server instance for the Maven MCP
 """
 
 import logging
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Annotated
+from pydantic import Field
 from fastmcp import FastMCP
 
 # Import the consolidated tools
@@ -234,11 +235,11 @@ def list_available_versions_tool(
 )
 def scan_java_project_tool(
     workspace: str,
-    include_profiles: Optional[List[str]] = None,
+    include_profiles: Annotated[Optional[List[str]], Field(default=None, description="List of Maven profiles to activate")] = None,
     scan_all_modules: bool = True,
     scan_mode: str = "workspace",
     pom_file: Optional[str] = None,
-    severity_filter: Optional[List[str]] = None,
+    severity_filter: Annotated[Optional[List[str]], Field(default=None, description="List of severity levels to include (CRITICAL, HIGH, MEDIUM, LOW)")] = None,
     max_results: int = 100,
     offset: int = 0,
 ):


### PR DESCRIPTION
## Problem

The MCP server was advertising `include_profiles` and `severity_filter` as string parameters, but the function expected arrays, causing validation errors.

## Solution

Use Pydantic's `Annotated` type with `Field` to explicitly declare array schemas:
- `include_profiles`: `Annotated[Optional[List[str]], Field(...)]`
- `severity_filter`: `Annotated[Optional[List[str]], Field(...)]`

This ensures FastMCP generates correct JSON schema for MCP clients.

## Testing

✅ All integration tests passing
✅ Schema should now correctly accept arrays

## Example Usage (After Fix)

```json
{
  "workspace": "./repos/partition",
  "include_profiles": ["azure"],
  "severity_filter": ["CRITICAL", "HIGH"],
  "max_results": 100
}
```